### PR TITLE
Add limit=250 query param and other improvements

### DIFF
--- a/shopify.py
+++ b/shopify.py
@@ -16,7 +16,7 @@ def get_page(url, page, collection_handle=None):
         full_url += '/collections/{}'.format(collection_handle)
     full_url += '/products.json'
     req = urllib.request.Request(
-        full_url + '?page={}'.format(page),
+        full_url + '?limit=250&page={}'.format(page),
         data=None,
         headers={
             'User-Agent': USER_AGENT

--- a/shopify.py
+++ b/shopify.py
@@ -130,7 +130,7 @@ def extract_products_collection(url, col):
 
 
 def extract_products(url, path, collections=None):
-    with open(path, 'w', encoding="utf-8") as f:
+    with open(path, 'w', encoding='utf-8', newline='') as f:
         writer = csv.writer(f)
         writer.writerow(['Code', 'Collection', 'Category',
                          'Name', 'Variant Name',

--- a/shopify.py
+++ b/shopify.py
@@ -130,7 +130,7 @@ def extract_products_collection(url, col):
 
 
 def extract_products(url, path, collections=None):
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(['Code', 'Collection', 'Category',
                          'Name', 'Variant Name',


### PR DESCRIPTION
The default number of products returned per call (from [the docs](https://help.shopify.com/en/api/reference/products/product)) is 50 items. This change will get 250 products per API call, decreasing the number of calls necessary to scrape a full catalog by (theoretically) 5x :)